### PR TITLE
Compatibility with L5.3. Change is() method to isRole(). Conflicts with Model::is()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Roles And Permissions For Laravel 5
+# Roles And Permissions For Laravel 5.3
 
 Powerful package for handling roles and permissions in Laravel 5.3.
 
@@ -34,7 +34,7 @@ Pull this package in through Composer (file `composer.json`).
 ```js
 {
     "require": {
-        "php": ">=5.6.5",
+        "php": ">=5.6.4",
         "laravel/framework": "5.3.*",
         "bican/roles": "2.1.*"
     }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Roles And Permissions For Laravel 5
 
-Powerful package for handling roles and permissions in Laravel 5 (5.1 and also 5.0).
+Powerful package for handling roles and permissions in Laravel 5.3.
 
 - [Installation](#installation)
     - [Composer](#composer)
@@ -34,8 +34,8 @@ Pull this package in through Composer (file `composer.json`).
 ```js
 {
     "require": {
-        "php": ">=5.5.9",
-        "laravel/framework": "5.1.*",
+        "php": ">=5.6.5",
+        "laravel/framework": "5.3.*",
         "bican/roles": "2.1.*"
     }
 }
@@ -141,7 +141,7 @@ $user->detachAllRoles(); // in case you want to detach all roles
 You can now check if the user has required role.
 
 ```php
-if ($user->is('admin')) { // you can pass an id or slug
+if ($user->isRole('admin')) { // you can pass an id or slug
     // or alternatively $user->hasRole('admin')
 }
 ```
@@ -157,20 +157,20 @@ if ($user->isAdmin()) {
 And of course, there is a way to check for multiple roles:
 
 ```php
-if ($user->is('admin|moderator')) { 
+if ($user->isRole('admin|moderator')) { 
     /*
     | Or alternatively:
-    | $user->is('admin, moderator'), $user->is(['admin', 'moderator']),
+    | $user->isRole('admin, moderator'), $user->isRole(['admin', 'moderator']),
     | $user->isOne('admin|moderator'), $user->isOne('admin, moderator'), $user->isOne(['admin', 'moderator'])
     */
 
     // if user has at least one role
 }
 
-if ($user->is('admin|moderator', true)) {
+if ($user->isRole('admin|moderator', true)) {
     /*
     | Or alternatively:
-    | $user->is('admin, moderator', true), $user->is(['admin', 'moderator'], true),
+    | $user->isRole('admin, moderator', true), $user->isRole(['admin', 'moderator'], true),
     | $user->isAll('admin|moderator'), $user->isAll('admin, moderator'), $user->isAll(['admin', 'moderator'])
     */
 
@@ -294,7 +294,7 @@ if ($user->allowed('edit.articles', $article, false)) { // now owner check is di
 There are four Blade extensions. Basically, it is replacement for classic if statements.
 
 ```php
-@role('admin') // @if(Auth::check() && Auth::user()->is('admin'))
+@role('admin') // @if(Auth::check() && Auth::user()->isRole('admin'))
     // user is admin
 @endrole
 
@@ -310,7 +310,7 @@ There are four Blade extensions. Basically, it is replacement for classic if sta
     // show edit button
 @endallowed
 
-@role('admin|moderator', 'all') // @if(Auth::check() && Auth::user()->is('admin|moderator', 'all'))
+@role('admin|moderator', 'all') // @if(Auth::check() && Auth::user()->isRole('admin|moderator', 'all'))
     // user is admin and also moderator
 @else
     // something else

--- a/src/Bican/Roles/Contracts/HasRoleAndPermission.php
+++ b/src/Bican/Roles/Contracts/HasRoleAndPermission.php
@@ -27,7 +27,7 @@ interface HasRoleAndPermission
      * @param bool $all
      * @return bool
      */
-    public function is($role, $all = false);
+    public function isRole($role, $all = false);
 
     /**
      * Check if the user has all roles.

--- a/src/Bican/Roles/Middleware/VerifyRole.php
+++ b/src/Bican/Roles/Middleware/VerifyRole.php
@@ -35,7 +35,7 @@ class VerifyRole
      */
     public function handle($request, Closure $next, $role)
     {
-        if ($this->auth->check() && $this->auth->user()->is($role)) {
+        if ($this->auth->check() && $this->auth->user()->isRole($role)) {
             return $next($request);
         }
 

--- a/src/Bican/Roles/RolesServiceProvider.php
+++ b/src/Bican/Roles/RolesServiceProvider.php
@@ -44,7 +44,7 @@ class RolesServiceProvider extends ServiceProvider
         $blade = $this->app['view']->getEngineResolver()->resolve('blade')->getCompiler();
 
         $blade->directive('role', function ($expression) {
-            return "<?php if (Auth::check() && Auth::user()->is{$expression}): ?>";
+            return "<?php if (Auth::check() && Auth::user()->isRole{$expression}): ?>";
         });
 
         $blade->directive('endrole', function () {

--- a/src/Bican/Roles/Traits/HasRoleAndPermission.php
+++ b/src/Bican/Roles/Traits/HasRoleAndPermission.php
@@ -49,7 +49,7 @@ trait HasRoleAndPermission
      * @param bool $all
      * @return bool
      */
-    public function is($role, $all = false)
+    public function isRole($role, $all = false)
     {
         if ($this->isPretendEnabled()) {
             return $this->pretend('is');
@@ -100,7 +100,7 @@ trait HasRoleAndPermission
      */
     public function hasRole($role)
     {
-        return $this->getRoles()->contains(function ($key, $value) use ($role) {
+        return $this->getRoles()->contains(function ($value, $key) use ($role) {
             return $role == $value->id || Str::is($role, $value->slug);
         });
     }
@@ -248,7 +248,7 @@ trait HasRoleAndPermission
      */
     public function hasPermission($permission)
     {
-        return $this->getPermissions()->contains(function ($key, $value) use ($permission) {
+        return $this->getPermissions()->contains(function ($value, $key) use ($permission) {
             return $permission == $value->id || Str::is($permission, $value->slug);
         });
     }

--- a/src/config/roles.php
+++ b/src/config/roles.php
@@ -60,7 +60,7 @@ return [
         'enabled' => false,
 
         'options' => [
-            'is' => true,
+            'isRole' => true,
             'can' => true,
             'allowed' => true,
         ],


### PR DESCRIPTION
Upgrade Notes from Laravel Docs: 
The first, last, and contains collection methods all pass the "value" as the first parameter to their given callback Closure. For example:

$collection->first(function ($value, $key) {
    return ! is_null($value);
});
In previous versions of Laravel, the $key was passed first. Since most use cases are only interested in the $value it is now passed first. You should do a "global find" in your application for these methods to verify that you are expecting the $value to be passed as the first argument to your Closure.