### PR TITLE
Fix down() in create_role_user_table migration

### DIFF
--- a/database/migrations/create_role_user_table.php
+++ b/database/migrations/create_role_user_table.php
@@ -28,10 +28,12 @@ class CreateRoleUserTable extends Migration
      *
      * @return void
      */
-    public function down(Blueprint $table)
+    public function down()
     {
-        $table->dropForeign('role_user_role_id_foreign');
-        $table->dropForeign('role_user_user_id_foreign');
+		Schema::table('role_user', function (Blueprint $table) {
+			$table->dropForeign('role_user_role_id_foreign');
+			$table->dropForeign('role_user_user_id_foreign');
+		});
         Schema::dropIfExists('role_user');
     }
 }


### PR DESCRIPTION
The `down()` method throws an error because it should not accept any arguments. 
The table maipulating should be by `Scehma` class inside `down()`.